### PR TITLE
Create speakers page

### DIFF
--- a/zcon/speakers.md
+++ b/zcon/speakers.md
@@ -4,7 +4,7 @@ title: Zcon0 Speakers
 excerpt: "The speakers who will give talks and workshops at Zcon0."
 ---
 
-Confirmed [Zcon0](https://z.cash.foundation//zcon/) speakers include:
+Confirmed [Zcon0](https://z.cash.foundation//zcon/) speakers/workshop hosts include:
 
 Name | Affiliation
 ------------ | -------------

--- a/zcon/speakers.md
+++ b/zcon/speakers.md
@@ -10,7 +10,6 @@ Name | Affiliation
 ------------ | -------------
 Nathan Wilcox | Zcash Company, CTO
 David Vorick | Sia, Cofounder
-Justin Smith | XMR Systems, CEO
 Jonathan Rouach | QED-it, CEO
 Ian Muñoz | Zcash Company, DevOps
 Brad Miller | Zcash Company, Engineer
@@ -28,4 +27,4 @@ Marshall Gaucher | Zcash Company, Engineer
 Nic Carter | Coinmetrics.io, Cocreator
 Sean Bowe | Zcash Company, Engineer
 Daniel Benarroch | QED-it, Lead Cryptographer
-Ayo Akinyele | Researcher
+J. Ayo Akinyele | YeleTech Security, President 

--- a/zcon/speakers.md
+++ b/zcon/speakers.md
@@ -1,0 +1,31 @@
+---
+layout: page
+title: Zcon0 Speakers
+excerpt: "The speakers who will give talks and workshops at Zcon0."
+---
+
+Confirmed [Zcon0](https://z.cash.foundation//zcon/) speakers include:
+
+Name | Affiliation
+------------ | -------------
+Nathan Wilcox | Zcash Company, CTO
+David Vorick | Sia, Cofounder
+Justin Smith | XMR Systems, CEO
+Jonathan Rouach | QED-it, CEO
+Ian Muñoz | Zcash Company, DevOps
+Brad Miller | Zcash Company, Engineer
+Izaak Meckler | Coda, CTO
+Mary Maller | University College London, Researcher
+Linda Naeun Lee | Zcash Company, UX Researcher
+Hudson Jameson | Ethereum Foundation
+Jack (str4d) Grigg | Zcash Company, Engineer
+Matthew Green | Johns Hopkins, Cryptographer
+Nicola Greco | Protocol Labs, Engineer
+Jay Graber | Zcash Company, Engineer
+Ariel Gazibon | Zcash Company, Engineer
+Jack (Dodger) Gavigan | Zcash Company, COO
+Marshall Gaucher | Zcash Company, Engineer
+Nic Carter | Coinmetrics.io, Cocreator
+Sean Bowe | Zcash Company, Engineer
+Daniel Benarroch | QED-it, Lead Cryptographer
+Ayo Akinyele | Researcher


### PR DESCRIPTION
A couple of things:

1) I wasn't sure if the order from Eventory was meaningful. I can group people by company or do alphabetical order or whatever if that makes more sense.

2) I googled Ayo Akinyele and it looks like he usually has a J. or Joseph in front of the rest of his name? Not sure if the most prominent person with this name just happens to also be in infosec or something like that.

3) AFAICT this is creating a separate page? Should we then add a link to it on the main Zcon0 page?